### PR TITLE
경로가 달라 리소스를 찾지 못했던 오류 수정

### DIFF
--- a/src/main/java/uhs/alphabet/domain/badge/StuBadge.java
+++ b/src/main/java/uhs/alphabet/domain/badge/StuBadge.java
@@ -1,6 +1,18 @@
 package uhs.alphabet.domain.badge;
 
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.InputStreamReader;
+import java.net.URL;
 import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -9,21 +21,23 @@ public class StuBadge {
     private final String name;
     private final String handle;
     private final String badge;
+    private final ResourceLoader loader;
 
-    public StuBadge(final String name, final String handle) {
+    public StuBadge(final String name, final String handle, ResourceLoader loader) {
         this.name = name;
         this.handle = handle;
+        this.loader = loader;
         String ret = "";
         try {
-            System.out.println(ClassLoader.getSystemResource("static/badge/stuBadge").toURI().toString());
-            String s = ClassLoader.getSystemResource("static/badge/stuBadge").toURI().toString();
-            Path stuBadge = Path.of(ClassLoader.getSystemResource("static/badge/stuBadge").toURI());
-            byte[] bytes = Files.readAllBytes(stuBadge);
-            Charset charset = Charset.forName("UTF-8");
-            ByteBuffer buffer = ByteBuffer.wrap(bytes);
-            ret = charset.decode(buffer).toString()
-                    .replaceAll("\\{(name)}", name)
-                    .replaceAll("\\{(handle)}", handle);
+            Resource resource = loader.getResource("classpath:static/badge/stuBadge");
+            File file = resource.getFile();
+            FileReader reader = new FileReader(file);
+            BufferedReader bufferedReader = new BufferedReader(reader);
+            String tmp;
+            while ((tmp = bufferedReader.readLine()) != null) {
+                ret+=tmp;
+            }
+            ret = ret.replaceAll("\\{(name)}", name).replaceAll("\\{(handle)}", handle);
         }
         catch (Exception e) {
             System.out.println(e.toString());

--- a/src/main/java/uhs/alphabet/web/IndexController.java
+++ b/src/main/java/uhs/alphabet/web/IndexController.java
@@ -1,6 +1,8 @@
 package uhs.alphabet.web;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -31,7 +33,7 @@ public class IndexController {
 
     private final PersonService personService;
     private final BoardService boardService;
-
+    private final ResourceLoader resourceLoader;
     public String getUserIp() throws Exception {
 
         HttpServletRequest request =
@@ -222,7 +224,7 @@ public class IndexController {
             handle = personDtos.get(0).getHandle();
             name = personDtos.get(0).getName();
         }
-        StuBadge badge = new StuBadge(name, handle);
+        StuBadge badge = new StuBadge(name, handle, resourceLoader);
         return new ResponseEntity<String>(badge.getBadge(), HttpStatus.OK);
     }
 


### PR DESCRIPTION
자바 클래스로더가 리소스를 찾는 시작 위치가 스프링 리소스 구조와 달랐다
스프링에서 제공하는 리소스 로더를 이용하여 리소스 찾게 수정