### PR TITLE
바이트 어레이를 딱맞게 할당

### DIFF
--- a/src/main/java/uhs/alphabet/domain/badge/StuBadge.java
+++ b/src/main/java/uhs/alphabet/domain/badge/StuBadge.java
@@ -29,7 +29,7 @@ public class StuBadge {
         try {
             Resource resource = loader.getResource("classpath:/static/badge/stuBadge");
             InputStream in = resource.getInputStream();
-            byte[] bytes = new byte[15024];
+            byte[] bytes = in.readAllBytes();
             int read = in.read(bytes);
             ByteBuffer buffer = ByteBuffer.wrap(bytes);
             Charset charset = Charset.forName("UTF-8");


### PR DESCRIPTION
여분의 공간이 할당되면 Extra content at the end of the document 에러가 표시되어 딱 맞게 할당함