### PR TITLE
Issue 125  리팩토링 보드서비스의 search posts 메소드 리팩토링

### DIFF
--- a/src/main/java/uhs/alphabet/board/BoardDto.java
+++ b/src/main/java/uhs/alphabet/board/BoardDto.java
@@ -2,6 +2,7 @@ package uhs.alphabet.board;
 
 import lombok.*;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
@@ -53,5 +54,23 @@ public class BoardDto {
         this.writer = writer;
         this.ip = ip;
         this.visible = visible;
+    }
+
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    public static BoardDto convertEntityToDto(final BoardEntity boardEntity) {
+        LocalDateTime time = boardEntity.getCreatedTime();
+        String formatDateTime = time.format(formatter);
+        return BoardDto.builder()
+                .board_id(boardEntity.getBoard_id())
+                .title(boardEntity.getTitle())
+                .content(boardEntity.getContent())
+                .pw(boardEntity.getPw())
+                .count(boardEntity.getCount())
+                .visible(boardEntity.isVisible())
+                .writer(boardEntity.getWriter())
+                .created_time(formatDateTime)
+                .ip(boardEntity.getIp())
+                .modified_time(boardEntity.getModified_time())
+                .build();
     }
 }

--- a/src/main/java/uhs/alphabet/board/BoardEntity.java
+++ b/src/main/java/uhs/alphabet/board/BoardEntity.java
@@ -57,7 +57,13 @@ public class BoardEntity extends TimeEntity {
     public SearchBoardDTO getSearchBoardDTO() {
         LocalDateTime time = getCreatedTime();
         String formatDateTime = time.format(formatter);
-        return new SearchBoardDTO(board_id, title, content, pw, count, formatDateTime, getModified_time(), visible, ip, writer);
+        return new SearchBoardDTO.SearchBoardDTOBuilder(board_id)
+                .setTitle(title)
+                .setCount(count)
+                .setCreatedTime(formatDateTime)
+                .setVisible(visible)
+                .setWrite(writer)
+                .build();
     }
 
 }

--- a/src/main/java/uhs/alphabet/board/BoardEntity.java
+++ b/src/main/java/uhs/alphabet/board/BoardEntity.java
@@ -1,7 +1,7 @@
 package uhs.alphabet.board;
 
 import lombok.*;
-import uhs.alphabet.board.dto.searchBoardDTO;
+import uhs.alphabet.board.dto.SearchBoardDTO;
 import uhs.alphabet.domain.entity.TimeEntity;
 
 import javax.persistence.*;
@@ -41,6 +41,7 @@ public class BoardEntity extends TimeEntity {
     @Column
     private String writer;
 
+    private final static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     @Builder
     public BoardEntity(Long board_id, String title, String content, String pw, int count, String ip, boolean visible, String writer) {
         this.board_id = board_id;
@@ -53,11 +54,10 @@ public class BoardEntity extends TimeEntity {
         this.writer = writer;
     }
 
-    public searchBoardDTO getSearchBoardDTO() {
+    public SearchBoardDTO getSearchBoardDTO() {
         LocalDateTime time = getCreatedTime();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
         String formatDateTime = time.format(formatter);
-        return new searchBoardDTO(board_id, title, content, pw, count, formatDateTime, getModified_time(), visible, ip, writer);
+        return new SearchBoardDTO(board_id, title, content, pw, count, formatDateTime, getModified_time(), visible, ip, writer);
     }
 
 }

--- a/src/main/java/uhs/alphabet/board/BoardEntity.java
+++ b/src/main/java/uhs/alphabet/board/BoardEntity.java
@@ -1,9 +1,12 @@
 package uhs.alphabet.board;
 
 import lombok.*;
+import uhs.alphabet.board.dto.searchBoardDTO;
 import uhs.alphabet.domain.entity.TimeEntity;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -50,5 +53,11 @@ public class BoardEntity extends TimeEntity {
         this.writer = writer;
     }
 
+    public searchBoardDTO getSearchBoardDTO() {
+        LocalDateTime time = getCreatedTime();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        String formatDateTime = time.format(formatter);
+        return new searchBoardDTO(board_id, title, content, pw, count, formatDateTime, getModified_time(), visible, ip, writer);
+    }
 
 }

--- a/src/main/java/uhs/alphabet/board/BoardRepository.java
+++ b/src/main/java/uhs/alphabet/board/BoardRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface BoardRepository extends JpaRepository<BoardEntity, Long> {
-    List<BoardEntity> findByTitleContaining(String key);
+    List<BoardEntity> findByTitleContaining(String title);
 }

--- a/src/main/java/uhs/alphabet/board/BoardRepository.java
+++ b/src/main/java/uhs/alphabet/board/BoardRepository.java
@@ -1,10 +1,8 @@
 package uhs.alphabet.board;
 
-import uhs.alphabet.board.BoardEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<BoardEntity, Long> {
     List<BoardEntity> findByTitleContaining(String key);

--- a/src/main/java/uhs/alphabet/board/BoardRepository.java
+++ b/src/main/java/uhs/alphabet/board/BoardRepository.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface BoardRepository extends JpaRepository<BoardEntity, Long> {
     List<BoardEntity> findByTitleContaining(String title);
+    List<BoardEntity> findAllByTitle(String title);
 }

--- a/src/main/java/uhs/alphabet/board/BoardRepository.java
+++ b/src/main/java/uhs/alphabet/board/BoardRepository.java
@@ -4,8 +4,8 @@ import uhs.alphabet.board.BoardEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<BoardEntity, Long> {
     List<BoardEntity> findByTitleContaining(String key);
-
 }

--- a/src/main/java/uhs/alphabet/board/BoardService.java
+++ b/src/main/java/uhs/alphabet/board/BoardService.java
@@ -11,7 +11,7 @@ import java.util.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import uhs.alphabet.annotation.Timer;
-import uhs.alphabet.board.dto.searchBoardDTO;
+import uhs.alphabet.board.dto.SearchBoardDTO;
 
 @RequiredArgsConstructor
 @Service
@@ -132,9 +132,9 @@ public class BoardService {
 
     @Transactional
     @Timer
-    public List<searchBoardDTO> searchPosts2(String keyword) {
+    public List<SearchBoardDTO> searchPosts2(String keyword) {
         List<BoardEntity> boardEntities = boardRepository.findByTitleContaining(keyword);
-        List<searchBoardDTO> searchBoardDTOS = new ArrayList<>();
+        List<SearchBoardDTO> searchBoardDTOS = new ArrayList<>();
         if (boardEntities.isEmpty()) return searchBoardDTOS;
 
         boardEntities.forEach(entity -> {

--- a/src/main/java/uhs/alphabet/board/BoardService.java
+++ b/src/main/java/uhs/alphabet/board/BoardService.java
@@ -119,29 +119,14 @@ public class BoardService {
     public List<BoardDto> searchPosts(String keyword) {
         List<BoardEntity> boardEntities = boardRepository.findByTitleContaining(keyword);
         List<BoardDto> boardDtos = new ArrayList<>();
-
         if (boardEntities.isEmpty()) return boardDtos;
 
-        for (BoardEntity boardEntity : boardEntities) {
-            boardDtos.add(this.convertEntityToDto(boardEntity));
-        }
+        boardEntities.forEach(entity -> {
+            boardDtos.add(convertEntityToDto(entity));
+        });
 
         return boardDtos;
     }
-
-//    @Transactional
-//    @Timer
-//    public List<BoardDto> searchPosts2(String keyword) {
-//        Optional<BoardEntity> byTitleContaining2 = boardRepository2.findByTitleContaining(keyword);
-//        if (byTitleContaining2.isEmpty()) throw new RuntimeException("해당 제목을 가진 게시글을 찾을 수 없습니다.");
-//
-//        List<BoardDto> boardDtos = new ArrayList<>();
-//        byTitleContaining2.stream().forEach(o -> {
-//            BoardDto boardDto = this.convertEntityToDto(o);
-//            boardDtos.add(boardDto);
-//        });
-//        return boardDtos;
-//    }
 
     @Transactional
     @Timer

--- a/src/main/java/uhs/alphabet/board/BoardService.java
+++ b/src/main/java/uhs/alphabet/board/BoardService.java
@@ -119,13 +119,13 @@ public class BoardService {
     @Timer
     public List<BoardDto> searchPosts(String keyword) {
         List<BoardEntity> boardEntities = boardRepository.findByTitleContaining(keyword);
-        List<BoardDto> boardDtos = new ArrayList<>();
-        if (boardEntities.isEmpty()) return boardDtos;
 
+        if (boardEntities.isEmpty()) return Collections.EMPTY_LIST;
+
+        List<BoardDto> boardDtos = new ArrayList<>();
         boardEntities.forEach(entity -> {
             boardDtos.add(convertEntityToDto(entity));
         });
-
 
         return boardDtos;
     }

--- a/src/main/java/uhs/alphabet/board/BoardService.java
+++ b/src/main/java/uhs/alphabet/board/BoardService.java
@@ -11,9 +11,6 @@ import java.util.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import uhs.alphabet.annotation.Timer;
-import uhs.alphabet.board.BoardDto;
-import uhs.alphabet.board.BoardEntity;
-import uhs.alphabet.board.BoardRepository;
 
 @RequiredArgsConstructor
 @Service
@@ -131,6 +128,20 @@ public class BoardService {
 
         return boardDtos;
     }
+
+//    @Transactional
+//    @Timer
+//    public List<BoardDto> searchPosts2(String keyword) {
+//        Optional<BoardEntity> byTitleContaining2 = boardRepository2.findByTitleContaining(keyword);
+//        if (byTitleContaining2.isEmpty()) throw new RuntimeException("해당 제목을 가진 게시글을 찾을 수 없습니다.");
+//
+//        List<BoardDto> boardDtos = new ArrayList<>();
+//        byTitleContaining2.stream().forEach(o -> {
+//            BoardDto boardDto = this.convertEntityToDto(o);
+//            boardDtos.add(boardDto);
+//        });
+//        return boardDtos;
+//    }
 
     @Transactional
     @Timer

--- a/src/main/java/uhs/alphabet/board/BoardService.java
+++ b/src/main/java/uhs/alphabet/board/BoardService.java
@@ -11,6 +11,7 @@ import java.util.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import uhs.alphabet.annotation.Timer;
+import uhs.alphabet.board.dto.searchBoardDTO;
 
 @RequiredArgsConstructor
 @Service
@@ -125,7 +126,22 @@ public class BoardService {
             boardDtos.add(convertEntityToDto(entity));
         });
 
+
         return boardDtos;
+    }
+
+    @Transactional
+    @Timer
+    public List<searchBoardDTO> searchPosts2(String keyword) {
+        List<BoardEntity> boardEntities = boardRepository.findByTitleContaining(keyword);
+        List<searchBoardDTO> searchBoardDTOS = new ArrayList<>();
+        if (boardEntities.isEmpty()) return searchBoardDTOS;
+
+        boardEntities.forEach(entity -> {
+            searchBoardDTOS.add(entity.getSearchBoardDTO());
+        });
+
+        return searchBoardDTOS;
     }
 
     @Transactional

--- a/src/main/java/uhs/alphabet/board/BoardService.java
+++ b/src/main/java/uhs/alphabet/board/BoardService.java
@@ -101,7 +101,7 @@ public class BoardService {
     @Transactional
     @Timer
     public List<BoardDto> searchPosts(String keyword) {
-        List<BoardEntity> boardEntities = boardRepository.findByTitleContaining(keyword);
+        List<BoardEntity> boardEntities = boardRepository.findAllByTitle(keyword);
 
         if (boardEntities.isEmpty()) return Collections.EMPTY_LIST;
 
@@ -113,7 +113,7 @@ public class BoardService {
     @Transactional
     @Timer
     public List<SearchBoardDTO> searchPosts2(String keyword) {
-        List<BoardEntity> boardEntities = boardRepository.findByTitleContaining(keyword);
+        List<BoardEntity> boardEntities = boardRepository.findAllByTitle(keyword);
         if (boardEntities.isEmpty()) return Collections.EMPTY_LIST;
 
         return boardEntities.stream()

--- a/src/main/java/uhs/alphabet/board/dto/SearchBoardDTO.java
+++ b/src/main/java/uhs/alphabet/board/dto/SearchBoardDTO.java
@@ -18,24 +18,24 @@ public class SearchBoardDTO {
     private final String content;
     @NotBlank
     @Size(min = 4, max = 6)
-    private final String pw;
+    private final String password;
     private final int count;
     private final String created_time;
     private final LocalDateTime modified_time;
     private final boolean visible;
-    private final String ip;
+    private final String ipAddrres;
     private final String writer;
 
-    public SearchBoardDTO(Long boardId, String title, String content, String pw, int count, String created_time, LocalDateTime modified_time, boolean visible, String ip, String writer) {
+    public SearchBoardDTO(Long boardId, String title, String content, String password, int count, String created_time, LocalDateTime modified_time, boolean visible, String ipAddrres, String writer) {
         this.boardId = boardId;
         this.title = title;
         this.content = content;
-        this.pw = pw;
+        this.password = password;
         this.count = count;
         this.created_time = created_time;
         this.modified_time = modified_time;
         this.visible = visible;
-        this.ip = ip;
+        this.ipAddrres = ipAddrres;
         this.writer = writer;
     }
 }

--- a/src/main/java/uhs/alphabet/board/dto/SearchBoardDTO.java
+++ b/src/main/java/uhs/alphabet/board/dto/SearchBoardDTO.java
@@ -3,39 +3,68 @@ package uhs.alphabet.board.dto;
 import lombok.Getter;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Size;
-import java.time.LocalDateTime;
-
 /*
 * DB에서 어플리케이션으로 board 정보를 가져올때 사용하는 DTO
+* 게시글 리스트 조회용 DTO
 * */
 @Getter
 public class SearchBoardDTO {
     private final Long boardId;
     @NotBlank
     private final String title;
-    @NotBlank
-    private final String content;
-    @NotBlank
-    @Size(min = 4, max = 6)
-    private final String password;
     private final int count;
-    private final String created_time;
-    private final LocalDateTime modified_time;
+    private final String createdTime;
     private final boolean visible;
-    private final String ipAddrres;
     private final String writer;
 
-    public SearchBoardDTO(Long boardId, String title, String content, String password, int count, String created_time, LocalDateTime modified_time, boolean visible, String ipAddrres, String writer) {
-        this.boardId = boardId;
-        this.title = title;
-        this.content = content;
-        this.password = password;
-        this.count = count;
-        this.created_time = created_time;
-        this.modified_time = modified_time;
-        this.visible = visible;
-        this.ipAddrres = ipAddrres;
-        this.writer = writer;
+    public SearchBoardDTO(SearchBoardDTOBuilder builder) {
+        this.boardId = builder.boardId;
+        this.title = builder.title;
+        this.visible = builder.visible;
+        this.count = builder.count;
+        this.createdTime = builder.createdTime;;
+        this.writer = builder.writer;
+    }
+
+    public static class SearchBoardDTOBuilder {
+        private final Long boardId; // 필수값
+
+        private String title;
+        private int count;
+        private String createdTime;
+        private boolean visible;
+        private String writer;
+
+        public SearchBoardDTOBuilder(Long boardId) {
+            this.boardId = boardId;
+        }
+
+        public SearchBoardDTOBuilder setTitle(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public SearchBoardDTOBuilder setCount(int count) {
+            this.count = count;
+            return this;
+        }
+
+        public SearchBoardDTOBuilder setCreatedTime(String createdTime) {
+            this.createdTime = createdTime;
+            return this;
+        }
+
+        public SearchBoardDTOBuilder setVisible(boolean visible) {
+            this.visible = visible;
+            return this;
+        }
+
+        public SearchBoardDTOBuilder setWrite(String writer) {
+            this.writer = writer;
+            return this;
+        }
+        public SearchBoardDTO build() {
+            return new SearchBoardDTO(this);
+        }
     }
 }

--- a/src/main/java/uhs/alphabet/board/dto/SearchBoardDTO.java
+++ b/src/main/java/uhs/alphabet/board/dto/SearchBoardDTO.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 * DB에서 어플리케이션으로 board 정보를 가져올때 사용하는 DTO
 * */
 @Getter
-public class searchBoardDTO {
+public class SearchBoardDTO {
     private final Long board_id;
     @NotBlank
     private final String title;
@@ -26,7 +26,7 @@ public class searchBoardDTO {
     private final String ip;
     private final String writer;
 
-    public searchBoardDTO(Long board_id, String title, String content, String pw, int count, String created_time, LocalDateTime modified_time, boolean visible, String ip, String writer) {
+    public SearchBoardDTO(Long board_id, String title, String content, String pw, int count, String created_time, LocalDateTime modified_time, boolean visible, String ip, String writer) {
         this.board_id = board_id;
         this.title = title;
         this.content = content;

--- a/src/main/java/uhs/alphabet/board/dto/SearchBoardDTO.java
+++ b/src/main/java/uhs/alphabet/board/dto/SearchBoardDTO.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 * */
 @Getter
 public class SearchBoardDTO {
-    private final Long board_id;
+    private final Long boardId;
     @NotBlank
     private final String title;
     @NotBlank
@@ -26,8 +26,8 @@ public class SearchBoardDTO {
     private final String ip;
     private final String writer;
 
-    public SearchBoardDTO(Long board_id, String title, String content, String pw, int count, String created_time, LocalDateTime modified_time, boolean visible, String ip, String writer) {
-        this.board_id = board_id;
+    public SearchBoardDTO(Long boardId, String title, String content, String pw, int count, String created_time, LocalDateTime modified_time, boolean visible, String ip, String writer) {
+        this.boardId = boardId;
         this.title = title;
         this.content = content;
         this.pw = pw;

--- a/src/main/java/uhs/alphabet/board/dto/searchBoardDTO.java
+++ b/src/main/java/uhs/alphabet/board/dto/searchBoardDTO.java
@@ -1,0 +1,41 @@
+package uhs.alphabet.board.dto;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+/*
+* DB에서 어플리케이션으로 board 정보를 가져올때 사용하는 DTO
+* */
+@Getter
+public class searchBoardDTO {
+    private final Long board_id;
+    @NotBlank
+    private final String title;
+    @NotBlank
+    private final String content;
+    @NotBlank
+    @Size(min = 4, max = 6)
+    private final String pw;
+    private final int count;
+    private final String created_time;
+    private final LocalDateTime modified_time;
+    private final boolean visible;
+    private final String ip;
+    private final String writer;
+
+    public searchBoardDTO(Long board_id, String title, String content, String pw, int count, String created_time, LocalDateTime modified_time, boolean visible, String ip, String writer) {
+        this.board_id = board_id;
+        this.title = title;
+        this.content = content;
+        this.pw = pw;
+        this.count = count;
+        this.created_time = created_time;
+        this.modified_time = modified_time;
+        this.visible = visible;
+        this.ip = ip;
+        this.writer = writer;
+    }
+}

--- a/src/test/java/uhs/alphabet/domain/board/BoardRepositoryTest.java
+++ b/src/test/java/uhs/alphabet/domain/board/BoardRepositoryTest.java
@@ -1,0 +1,116 @@
+package uhs.alphabet.domain.board;
+
+import org.junit.After;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import uhs.alphabet.board.BoardEntity;
+import uhs.alphabet.board.BoardRepository;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@DataJpaTest
+public class BoardRepositoryTest {
+    @Autowired
+    private BoardRepository boardRepository;
+
+    private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    private final LocalDateTime now = LocalDateTime.now();
+
+    @After
+    public void cleanup() {
+        boardRepository.deleteAll();
+    }
+    @BeforeEach
+    public void cleanupEach() {
+        boardRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("saveBoard test 한번 저장")
+    public void saveBoard() {
+        BoardEntity entity = boardRepository.save(BoardEntity.builder()
+                .title("saveTestTitle")
+                .content("saveTestContent")
+                .pw("1234")
+                .visible(true)
+                .writer("writer")
+                .ip("ip")
+                .build()
+        );
+        List<BoardEntity> boardEntityWrapper = boardRepository.findByTitleContaining("saveTestTitle");
+        Assertions.assertEquals(false, boardEntityWrapper.isEmpty());
+
+        BoardEntity boardEntityTest = boardEntityWrapper.get(0);
+        Assertions.assertEquals(entity.getTitle(), boardEntityTest.getTitle());
+        Assertions.assertEquals(entity.getContent(), boardEntityTest.getContent());
+        Assertions.assertEquals(entity.getPw(), boardEntityTest.getPw());
+        Assertions.assertEquals(entity.getWriter(), boardEntityTest.getWriter());
+        Assertions.assertEquals(entity.getIp(), boardEntityTest.getIp());
+        Assertions.assertEquals(entity.isVisible(), boardEntityTest.isVisible());
+        Assertions.assertEquals(now.format(formatter), boardEntityTest.getCreatedTime().format(formatter));
+        Assertions.assertEquals(now.format(formatter), boardEntityTest.getModified_time().format(formatter));
+    }
+
+    @Test
+    @DisplayName("게시글을 하나 저장하고, 다시 삭제하는 테스트")
+    public void deleteBoard() {
+        boardRepository.save(BoardEntity.builder()
+                .title("deleteTestTitle")
+                .content("deleteTestContent")
+                .pw("1234")
+                .visible(true)
+                .writer("writer1")
+                .ip("ip1")
+                .build()
+        );
+        List<BoardEntity> boardEntities = boardRepository.findByTitleContaining("deleteTest");
+        Assertions.assertEquals(false, boardEntities.isEmpty());
+
+        BoardEntity boardEntity = boardEntities.get(0);
+        boardRepository.deleteById(boardEntity.getBoard_id());
+
+        List<BoardEntity> deleteTest = boardRepository.findByTitleContaining("deleteTest");
+        Assertions.assertEquals(true, deleteTest.isEmpty());
+    }
+
+    @Test
+    @DisplayName("게시글을 여러개를 저장하고 등록한 게시글 모두를 조회하는 테스트")
+    public void searchBoardTest() {
+        boardRepository.save(BoardEntity.builder()
+                .title("searchTestTitle1")
+                .content("deleteTestContent")
+                .pw("1234")
+                .visible(true)
+                .writer("writer1")
+                .ip("ip1")
+                .build()
+        );
+        boardRepository.save(BoardEntity.builder()
+                .title("searchTestTitle2")
+                .content("deleteTestContent")
+                .pw("1234")
+                .visible(true)
+                .writer("writer1")
+                .ip("ip1")
+                .build()
+        );
+        boardRepository.save(BoardEntity.builder()
+                .title("searchTestTitle3")
+                .content("deleteTestContent")
+                .pw("1234")
+                .visible(true)
+                .writer("writer1")
+                .ip("ip1")
+                .build()
+        );
+        List<BoardEntity> searchTest = boardRepository.findByTitleContaining("searchTest");
+        Assertions.assertEquals(false, searchTest.isEmpty());
+        Assertions.assertEquals(3, searchTest.size());
+    }
+}

--- a/src/test/java/uhs/alphabet/domain/repository/RepositoryTest.java
+++ b/src/test/java/uhs/alphabet/domain/repository/RepositoryTest.java
@@ -4,8 +4,6 @@ import org.junit.After;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import uhs.alphabet.board.BoardEntity;
-import uhs.alphabet.board.BoardRepository;
 import uhs.alphabet.domain.entity.PersonEntity;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -13,9 +11,6 @@ import java.util.List;
 
 @SpringBootTest
 public class RepositoryTest {
-
-    @Autowired
-    private BoardRepository boardRepository;
     @Autowired
     private PersonRepository personRepository;
 
@@ -25,67 +20,10 @@ public class RepositoryTest {
     @After
     public void cleanup() {
         personRepository.deleteAll();
-        boardRepository.deleteAll();
     }
     @BeforeEach
     public void cleanupEach() {
         personRepository.deleteAll();
-        boardRepository.deleteAll();
-    }
-
-    /*
-    * saveBoard을 테스트합니다
-    */
-    @Test
-    @DisplayName("saveBoard test 한번 저장")
-    public void saveBoard() {
-        BoardEntity entity = boardRepository.save(BoardEntity.builder()
-                .title("saveTestTitle")
-                .content("saveTestContent")
-                .pw("1234")
-                .visible(true)
-                .writer("writer")
-                .ip("ip")
-                .build()
-        );
-        now = LocalDateTime.now();
-        List<BoardEntity> boardEntityWrapper = boardRepository.findByTitleContaining("saveTestTitle");
-        BoardEntity boardEntityTest = boardEntityWrapper.get(0);
-
-        Assertions.assertEquals(1,boardEntityWrapper.size());
-        Assertions.assertEquals(entity.getTitle(), boardEntityTest.getTitle());
-        Assertions.assertEquals(entity.getContent(), boardEntityTest.getContent());
-        Assertions.assertEquals(entity.getPw(), boardEntityTest.getPw());
-        Assertions.assertEquals(entity.getWriter(), boardEntityTest.getWriter());
-        Assertions.assertEquals(entity.getIp(), boardEntityTest.getIp());
-        Assertions.assertEquals(entity.isVisible(), boardEntityTest.isVisible());
-        Assertions.assertEquals(now.format(formatter), boardEntityTest.getCreatedTime().format(formatter));
-        Assertions.assertEquals(now.format(formatter), boardEntityTest.getModified_time().format(formatter));
-    }
-
-    @Test
-    @DisplayName("게시글을 하나 저장하고, 다시 삭제하는 테스트")
-    public void deleteBoard() {
-        boardRepository.save(BoardEntity.builder()
-                .title("deleteTestTitle")
-                .content("deleteTestContent")
-                .pw("1234")
-                .visible(true)
-                .writer("writer1")
-                .ip("ip1")
-                .build()
-        );
-        now = LocalDateTime.now();
-        List<BoardEntity> boardEntities = boardRepository.findByTitleContaining("deleteTest");
-        int sz = boardEntities.size();
-        Assertions.assertEquals(sz, 1);
-
-        BoardEntity boardEntity = boardEntities.get(0);
-        boardRepository.deleteById(boardEntity.getBoard_id());
-
-        boardEntities = boardRepository.findByTitleContaining("deleteTest");
-        sz = boardEntities.size();
-        Assertions.assertEquals(sz, 0);
     }
 
     @Test


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
1. searchpost 메소드의 for loop를 stream으로 변환
가독성 향상을 위해 변경합니다

2. searchpost 메소드의 리턴타입을 List<boardDTO>에서 List<searchBoardDTO>로 변환
조회용 dto와 저장/업데이트용 dto를 분리하기 위해 변환합니다

3. 여러 도메인의 테스트가 한군데에 모여있어서 board도메인의 repository 테스트를 따로 추출
복잡도를 낮추기 위해 변경합니다

# 어떻게 해결했나요?
1. stream api사용하게 변경
2. 새로운 조회용 dto 생성(저장/업데이트용 dto는 새로운 이슈에서 개발)
3. 해당 테스트만 따로 빼서 테스트 클래스 생성 및 jpaDataTest를 적용

## Attachment
![asd drawio](https://user-images.githubusercontent.com/46879264/191708369-98f96ff1-cad5-4002-9919-f99ef6ce0f9e.png)

보드 엔티티가 타임 엔티티를 extends합니다
조회용 dto는 보드 엔티티에 포함됩니다